### PR TITLE
added playsinline setting for HTML5 player on iOS.

### DIFF
--- a/srt.js
+++ b/srt.js
@@ -59,7 +59,11 @@ function onYouTubeIframeAPIReady() {
     height: "390",
     width: "640",
     videoId: vid,
-    // playerVars: { "cc_load_policy": 1},// , "autoplay": autoplay},
+    playerVars: {
+			// "cc_load_policy": 1,
+			// "autoplay": autoplay,
+			"playsinline": 1
+		},
     events: {
       "onReady": onPlayerReady,
       "onStateChange": onPlayerStateChange


### PR DESCRIPTION
I added "playsinline" setting to the player object for avoiding fullscreen playback on iOS.
Please check it.